### PR TITLE
Fix forward declaration for InputController

### DIFF
--- a/Source/Core/Window/WindowObject.h
+++ b/Source/Core/Window/WindowObject.h
@@ -5,6 +5,8 @@
 #include <include/gl.h>
 #include <include/glm.h>
 
+class InputController; // forward declaration
+
 class WindowProperties
 {
 	public:


### PR DESCRIPTION
## Summary
- forward declare `InputController` in WindowObject.h

## Testing
- `cmake -S . -B build` *(fails: CMake 3.31 or higher is required)*

------
https://chatgpt.com/codex/tasks/task_e_6846d7a2c8ac832f8488334036c6da9a