### PR TITLE
Fix missing InputController declaration

### DIFF
--- a/Source/Core/Window/WindowObject.h
+++ b/Source/Core/Window/WindowObject.h
@@ -5,6 +5,9 @@
 #include <include/gl.h>
 #include <include/glm.h>
 
+// Forward declaration to avoid circular dependency with InputController
+class InputController;
+
 class WindowProperties
 {
 	public:


### PR DESCRIPTION
## Summary
- fix compilation by forward-declaring InputController in `WindowObject.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846ece0f2d0832fad853b070410a7af