### PR TITLE
Fix missing Windows header for wglew

### DIFF
--- a/Source/include/gl.h
+++ b/Source/include/gl.h
@@ -6,9 +6,12 @@
 	#define GLEW_ENABLED
 	#include <GL/glew.h>
 
-	#ifdef _WIN32
-		#include <GL/wglew.h>
-	#endif
+        #ifdef _WIN32
+                // Include Windows headers before wglew to ensure types like
+                // HGLRC and BOOL are available
+                #include <windows.h>
+                #include <GL/wglew.h>
+        #endif
 
 	#if defined(__linux__)
 		#include <GL/glxew.h>


### PR DESCRIPTION
## Summary
- add windows.h include before wglew.h to provide missing Windows types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846ee269218832fb8a379d7a4e77d91