### PR TITLE
Fix build errors by removing global using directive

### DIFF
--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -1,7 +1,6 @@
 #include <ctime>
 #include <iostream>
 
-using namespace std;
 
 #include <Core/Engine.h>
 


### PR DESCRIPTION
## Summary
- avoid name collision between Windows headers and C++17 `std::byte`
- remove `using namespace std;` from `Source/Main.cpp`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: GL/glu.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f0169358832f87b11f41787a35e4