### PR TITLE
Fix library paths for Windows 64-bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ file(GLOB_RECURSE SOURCES
 add_executable(Volume_Rendering ${SOURCES})
 
 target_link_directories(Volume_Rendering PRIVATE
-        libs/GLFW/x86/Debug
-        libs/GL/x86/Release
-        libs/Engine/x86/Debug
+        libs/GLFW/x64/Debug
+        libs/GL/x64/Release
+        libs/Engine/x64/Debug
 )
 
 target_link_libraries(Volume_Rendering


### PR DESCRIPTION
## Summary
- use x64 libs in `target_link_directories`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: GL/glu.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846f27c3564832fbe6bed0a95fe543d